### PR TITLE
fix: start_run cloud post is synchronous to ensure run exists before …

### DIFF
--- a/pipelinehub/store.py
+++ b/pipelinehub/store.py
@@ -102,8 +102,8 @@ class RunStore:
         with self._get_conn() as conn:
             conn.executescript(_SCHEMA)
 
-    def _cloud_post(self, path: str, payload: dict, method: str = "POST") -> None:
-        """Post data to cloud API in a background daemon thread."""
+    def _cloud_post(self, path: str, payload: dict, method: str = "POST", sync: bool = False) -> None:
+        """Post data to cloud API. sync=True blocks until complete (used for start_run)."""
         if not self._api_key:
             return
         api_key = self._api_key
@@ -121,12 +121,15 @@ class RunStore:
                         "Content-Type": "application/json",
                     },
                 )
-                urllib.request.urlopen(req, timeout=5)
+                urllib.request.urlopen(req, timeout=10)
             except Exception:
                 pass
 
-        t = threading.Thread(target=_send, daemon=True)
-        t.start()
+        if sync:
+            _send()
+        else:
+            t = threading.Thread(target=_send, daemon=False)
+            t.start()
 
     def start_run(self, pipeline_name: str, total_steps: int) -> str:
         """Insert a new run record. Returns the generated run_id."""
@@ -143,7 +146,7 @@ class RunStore:
             "started_at": started_at,
             "total_steps": total_steps,
             "status": "running",
-        })
+        }, sync=True)  # blocking — run must exist before steps are sent
         return run_id
 
     def save_step(

--- a/tests/test_store_cloud.py
+++ b/tests/test_store_cloud.py
@@ -109,7 +109,7 @@ class TestCloudPost:
                 # Must not raise
                 store._cloud_post("/v1/runs", {"run_id": "abc"})
 
-    def test_runs_in_daemon_thread(self):
+    def test_runs_in_non_daemon_thread(self):
         store = RunStore(db_path=":memory:", api_key="ph_live_x", api_url="http://localhost:8000")
         created_threads = []
         original_thread = threading.Thread
@@ -124,7 +124,7 @@ class TestCloudPost:
                 store._cloud_post("/v1/runs", {"run_id": "abc"})
                 if created_threads:
                     created_threads[0].join(timeout=1.0)
-                    assert created_threads[0].daemon is True
+                    assert created_threads[0].daemon is False
 
 
 class TestCloudSync:


### PR DESCRIPTION
…steps are sent