### PR TITLE
fix(profiler): exclude bool columns from numeric — prevents corr() crash

### DIFF
--- a/pipelinehub/__init__.py
+++ b/pipelinehub/__init__.py
@@ -14,7 +14,7 @@ from .utils import (
     outlier_removal,
 )
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"
 __author__ = "Rahul Paul"
 __email__ = "paul.rahulxj100@gmail.com"
 

--- a/pipelinehub/profiler.py
+++ b/pipelinehub/profiler.py
@@ -105,7 +105,8 @@ class DataProfiler:
         else:
             sample = df
         numeric_cols = [
-            c for c in columns if pd.api.types.is_numeric_dtype(df[c])
+            c for c in columns
+            if pd.api.types.is_numeric_dtype(df[c]) and not pd.api.types.is_bool_dtype(df[c])
         ]
         numeric_stats: Dict[str, Any] = {}
         for col in numeric_cols:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pipelinehub"
-version = "0.1.17"
+version = "0.1.18"
 authors = [
     {name = "Rahul Paul", email = "paul.rahulxj100@gmail.com"},
 ]
@@ -56,7 +56,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 
 [tool.bumpversion]
-current_version = "0.1.17"
+current_version = "0.1.18"
 commit = true
 tag = true
 message = "chore: bump version to {new_version} [skip ci]"


### PR DESCRIPTION
## Summary

- `_profile_pandas` was including boolean columns in `numeric_cols`
- `df[numeric_cols].corr()` crashes on bool columns — numpy can't subtract booleans
- The `except Exception` in `capture()` caught this silently and fell back to `_profile_generic`, returning only `{type_name, str_repr}` instead of full column statistics
- Fix: exclude `bool` dtype columns from `numeric_cols`

## Impact

Any DataFrame with a boolean column would silently lose all profiler stats — no row counts, column types, null rates, quantiles, or cardinality in the dashboard.

## Test plan
- [ ] Run demo with a DataFrame containing a bool column — confirms full profile returned
- [ ] `numeric_stats` contains only truly numeric (non-bool) columns
- [ ] `correlation` only computed between non-bool numeric columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)